### PR TITLE
Add create-cf-stack.sh to automate creation of CloudFormation stacks

### DIFF
--- a/cloudformation-api-lambda-dynamodb-sns-cb.yml
+++ b/cloudformation-api-lambda-dynamodb-sns-cb.yml
@@ -47,10 +47,6 @@ Parameters:
     Type: String
     Default: dev
 
-  AWSRegionSelected:
-    Type: String
-    Default: ap-southeast-1
-
   # *** This value must always be passed in when creating / updating stack
   # "NoEcho" is set to true, for security, so token won't be visible when examining the resulting stack
   GitHubToken:
@@ -98,7 +94,7 @@ Resources:
       Role: !GetAtt IAMRole.Arn
       Environment:
         Variables:
-          AWS_REGION_SELECTED: !Ref AWSRegionSelected
+          AWS_REGION_SELECTED: !Ref "AWS::Region"
           DYNAMO_DB_TABLE_NAME: !Ref DynamoDBTableName
           SIGNING_KEY: !Ref MailgunSigningKey
           SNS_TOPIC_ARN: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicName}

--- a/create-stacks.sh
+++ b/create-stacks.sh
@@ -33,6 +33,12 @@ cd lambda-node
 yarn install
 
 echo "Creating lambda fuction zip file to be uploaded to created S3 Bucket"
+
+if [ -f $S3_Key ]; then
+   rm $S3_Key
+   echo "$S3_Key file is removed for new build"
+fi
+
 yarn build-zip
 
 echo "Uploading lambda function zip file to s3"

--- a/create-stacks.sh
+++ b/create-stacks.sh
@@ -1,40 +1,29 @@
 #!/bin/bash
 
-# *** Change this to the desired name of the Cloudformation stack of 
-# your Pipeline (*not* the stack name of your app)
+# NOTE: BEFORE RUNNING YARN and AWS-CLI MUST BE INSTALLED IN YOUR SYSTEM
+
+# Change these variables if you need to
 AWS_REGION="ap-southeast-1"
-CLOUDFORMATION_S3_STACK_NAME="mailgunwebhook-s3"
+CLOUDFORMATION_S3_STACK_NAME="mailgunwebhook-s3-y"
 CLOUDFORMATION_MAIN_STACK_NAME="mailgunwebhook-main"
 S3_BUCKET_NAME="mailgunwebhookbucket"
 S3_Key="mailgunwebhooklambda.zip"
 
 
-if [ -z ${1} ]
-then
-	echo "STACK CREATION FAILED!- No Github Token"
-        echo "Pass your Github token as the first argument"
-	exit 1
-fi
-
-if [ -z ${2} ]
-then
-	echo "STACK CREATION FAILED!- No Mailgun Signing Key"
-        echo "Pass Mailgun webhook signing key as the second argument"
-	exit 1
-fi
-
-if [ -z ${3} ]
-then
-	echo "STACK CREATION FAILED!- No SNS subscription email"
-        echo "Pass email for SNS subscription signing key as the third argument"
-	exit 1
-fi
+# chose input than arguments for security purposes
+read -s -p "Enter Github Auth Token: " GITHUB_TOKEN
+echo
+read -s -p "Enter Mailgun Webhook Signing Key: " MAILGUN_KEY
+echo
+read -p "Enter email for AWS SNS Subscription: " SNS_EMAIL
+echo
 
 set -eu
 
 echo "Creating CloudFormation Stack for S3 Bucket lambda zip file"
 aws cloudformation create-stack \
         --region $AWS_REGION \
+        --no-cli-pager \
         --stack-name $CLOUDFORMATION_S3_STACK_NAME \
         --parameters ParameterKey=S3Bucket,ParameterValue=$S3_BUCKET_NAME \
         --template-body file://cloudformation-s3.yml
@@ -54,9 +43,10 @@ cd ..
 
 aws cloudformation create-stack \
         --region $AWS_REGION \
+        --no-cli-pager \
         --stack-name $CLOUDFORMATION_MAIN_STACK_NAME \
         --capabilities CAPABILITY_IAM \
         --template-body file://cloudformation-api-lambda-dynamodb-sns-cb.yml \
-        --parameters ParameterKey=S3Bucket,ParameterValue=$S3_BUCKET_NAME ParameterKey=GitHubToken,ParameterValue=${1} ParameterKey=MailgunSigningKey,ParameterValue=${2} ParameterKey=SNSSubscriptionEmail,ParameterValue=${3}
+        --parameters ParameterKey=S3Bucket,ParameterValue=$S3_BUCKET_NAME ParameterKey=GitHubToken,ParameterValue=$GITHUB_TOKEN ParameterKey=MailgunSigningKey,ParameterValue=$MAILGUN_KEY ParameterKey=SNSSubscriptionEmail,ParameterValue=$SNS_EMAIL
 
-
+echo "Executed Cloud Formation Create Commands"

--- a/create-stacks.sh
+++ b/create-stacks.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# *** Change this to the desired name of the Cloudformation stack of 
+# your Pipeline (*not* the stack name of your app)
+AWS_REGION="ap-southeast-1"
+CLOUDFORMATION_S3_STACK_NAME="mailgunwebhook-s3"
+CLOUDFORMATION_MAIN_STACK_NAME="mailgunwebhook-main"
+S3_BUCKET_NAME="mailgunwebhookbucket"
+S3_Key="mailgunwebhooklambda.zip"
+
+
+if [ -z ${1} ]
+then
+	echo "STACK CREATION FAILED!- No Github Token"
+        echo "Pass your Github token as the first argument"
+	exit 1
+fi
+
+if [ -z ${2} ]
+then
+	echo "STACK CREATION FAILED!- No Mailgun Signing Key"
+        echo "Pass Mailgun webhook signing key as the second argument"
+	exit 1
+fi
+
+if [ -z ${3} ]
+then
+	echo "STACK CREATION FAILED!- No SNS subscription email"
+        echo "Pass email for SNS subscription signing key as the third argument"
+	exit 1
+fi
+
+set -eu
+
+echo "Creating CloudFormation Stack for S3 Bucket lambda zip file"
+aws cloudformation create-stack \
+        --region $AWS_REGION \
+        --stack-name $CLOUDFORMATION_S3_STACK_NAME \
+        --parameters ParameterKey=S3Bucket,ParameterValue=$S3_BUCKET_NAME \
+        --template-body file://cloudformation-s3.yml
+
+echo "Installing project dependencies"
+cd lambda-node
+yarn install
+
+echo "Creating lambda fuction zip file to be uploaded to created S3 Bucket"
+yarn build-zip
+
+echo "Uploading lambda function zip file to s3"
+aws s3 cp ./$S3_Key  s3://$S3_BUCKET_NAME
+
+echo "Creating CloudFormation Main Stack"
+cd ..
+
+aws cloudformation create-stack \
+        --region $AWS_REGION \
+        --stack-name $CLOUDFORMATION_MAIN_STACK_NAME \
+        --capabilities CAPABILITY_IAM \
+        --template-body file://cloudformation-api-lambda-dynamodb-sns-cb.yml \
+        --parameters ParameterKey=S3Bucket,ParameterValue=$S3_BUCKET_NAME ParameterKey=GitHubToken,ParameterValue=${1} ParameterKey=MailgunSigningKey,ParameterValue=${2} ParameterKey=SNSSubscriptionEmail,ParameterValue=${3}
+
+


### PR DESCRIPTION
Added `create-cf-stack.sh` executable file to automate creation of CloudFormation Stacks required to process Mailgun webhooks